### PR TITLE
WIP: Convert temporal

### DIFF
--- a/mplaltair/_convert.py
+++ b/mplaltair/_convert.py
@@ -1,5 +1,6 @@
 from altair.utils.core import parse_shorthand
 from altair.utils.schemapi import Undefined
+import matplotlib.dates as mdates
 
 _mpl_temporal_equivalent = {
     'x': (lambda d: _process_temporal_x(d)),
@@ -35,6 +36,10 @@ def convert_temporal(chart):
     for encoding_channel in chart.to_dict()['encoding']:
         channel = chart.encoding[encoding_channel]
         data = _locate_channel_data(channel, chart.data)
+        try:
+            data = mdates.date2num(data)
+        except ValueError:
+            raise
         mapping[_mpl_temporal_equivalent[encoding_channel](data)[0]] = _mpl_temporal_equivalent[encoding_channel](data)[1]
 
     return mapping

--- a/mplaltair/_convert.py
+++ b/mplaltair/_convert.py
@@ -1,1 +1,108 @@
+from altair.utils.core import parse_shorthand
+from altair.utils.schemapi import Undefined
 
+_mpl_temporal_equivalent = {
+    'x': (lambda d: _process_x(d)),
+    'y': (lambda d: _process_y(d)),
+    'x2': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
+    'y2': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
+    'color': (lambda d: _process_color(d)),
+    'fill': (lambda d: _process_fill(d)),
+    'opacity': (lambda d: _process_opacity(d)),  # NotImplementedError for array-like opacities - MPL
+    'shape': (lambda d: _process_shape(d)),  # NotImplementedError - MPL
+    'size': (lambda d: _process_size(d)),
+    'stroke': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
+}
+
+
+def convert_temporal(chart):
+    """Convert temporal Altair encodings to their Matplotlib equivalents
+
+    Parameters
+    ----------
+    chart
+        The Altair chart
+
+    Returns
+    -------
+    mapping : dict
+        Mapping from parts of the encoding to the Matplotlib equivalent.
+
+    """
+
+    mapping = {}
+
+    for encoding_channel in chart.to_dict()['encoding']:
+        channel = chart.encoding[encoding_channel]
+        data = _locate_channel_data(channel, chart.data)
+        mapping[_mpl_temporal_equivalent[encoding_channel](data)[0]] = _mpl_temporal_equivalent[encoding_channel](data)[1]
+
+    return mapping
+
+
+def _locate_channel_data(channel, data):
+    """Locates data used for each channel
+
+    Parameters
+    ----------
+    channel
+        The encoding channel from the Altair chart
+    data : Pandas DataFrame
+        Data from the Altair chart
+
+    Returns
+    -------
+    A numpy ndarray containing the data used for the channel
+
+    """
+
+    if hasattr(channel, "value") and channel.value is not Undefined:  # from the value version of the channel
+        return channel.value
+    elif hasattr(channel, "aggregate") and channel.aggregate is not Undefined:
+        return _aggregate_channel()
+    elif hasattr(channel, "field") and channel.field is not Undefined:
+        return data[channel.field].values
+    elif hasattr(channel, "shorthand") and channel.shorthand is not Undefined:
+        parsed = parse_shorthand(channel.shorthand, data)
+        if "aggregate" in parsed:
+            return _aggregate_channel()
+        elif "field" in parsed:
+            return data[parsed['field']].values
+    else:
+        raise ValueError("Cannot find data for the channel")
+
+
+def _aggregate_channel():
+    raise NotImplementedError
+
+
+def _process_x(data):
+    return "x", data
+
+
+def _process_y(data):
+    return "y", data
+
+
+def _process_color(data):
+    raise NotImplementedError
+
+
+def _process_fill(data):
+    raise NotImplementedError
+
+
+def _process_opacity(data):
+    raise NotImplementedError
+
+
+def _process_shape(data):
+    raise NotImplementedError
+
+
+def _process_size(data):
+    raise NotImplementedError
+
+
+def _process_not_implemented(data):
+    raise NotImplementedError

--- a/mplaltair/_convert.py
+++ b/mplaltair/_convert.py
@@ -10,7 +10,7 @@ _mpl_temporal_equivalent = {
     'fill': (lambda d: _process_fill(d)),
     'opacity': (lambda d: _process_opacity(d)),  # NotImplementedError for array-like opacities - MPL
     'shape': (lambda d: _process_shape(d)),  # NotImplementedError - MPL
-    'size': (lambda d: _process_size(d)),
+    'size': (lambda d: _process_size(d)),  # NotImplementedError - MPL
     'stroke': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
 }
 
@@ -85,11 +85,11 @@ def _process_y(data):
 
 
 def _process_color(data):
-    raise NotImplementedError
+    return "c", data
 
 
 def _process_fill(data):
-    raise NotImplementedError
+    return "c", data
 
 
 def _process_opacity(data):

--- a/mplaltair/_convert.py
+++ b/mplaltair/_convert.py
@@ -2,16 +2,16 @@ from altair.utils.core import parse_shorthand
 from altair.utils.schemapi import Undefined
 
 _mpl_temporal_equivalent = {
-    'x': (lambda d: _process_x(d)),
-    'y': (lambda d: _process_y(d)),
-    'x2': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
-    'y2': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
-    'color': (lambda d: _process_color(d)),
-    'fill': (lambda d: _process_fill(d)),
-    'opacity': (lambda d: _process_opacity(d)),  # NotImplementedError for array-like opacities - MPL
-    'shape': (lambda d: _process_shape(d)),  # NotImplementedError - MPL
-    'size': (lambda d: _process_size(d)),  # NotImplementedError - MPL
-    'stroke': (lambda d: _process_not_implemented(d)),  # NotImplementedError - ALT
+    'x': (lambda d: _process_temporal_x(d)),
+    'y': (lambda d: _process_temporal_y(d)),
+    'x2': (lambda d: _process_temporal_not_implemented(d)),  # NotImplementedError - ALT
+    'y2': (lambda d: _process_temporal_not_implemented(d)),  # NotImplementedError - ALT
+    'color': (lambda d: _process_temporal_color(d)),
+    'fill': (lambda d: _process_temporal_fill(d)),
+    'opacity': (lambda d: _process_temporal_opacity(d)),  # NotImplementedError - MPL
+    'shape': (lambda d: _process_temporal_shape(d)),  # NotImplementedError - MPL
+    'size': (lambda d: _process_temporal_size(d)),  # NotImplementedError - MPL
+    'stroke': (lambda d: _process_temporal_not_implemented(d)),  # NotImplementedError - ALT
 }
 
 
@@ -76,33 +76,33 @@ def _aggregate_channel():
     raise NotImplementedError
 
 
-def _process_x(data):
+def _process_temporal_x(data):
     return "x", data
 
 
-def _process_y(data):
+def _process_temporal_y(data):
     return "y", data
 
 
-def _process_color(data):
+def _process_temporal_color(data):
     return "c", data
 
 
-def _process_fill(data):
+def _process_temporal_fill(data):
     return "c", data
 
 
-def _process_opacity(data):
+def _process_temporal_opacity(data):
     raise NotImplementedError
 
 
-def _process_shape(data):
+def _process_temporal_shape(data):
     raise NotImplementedError
 
 
-def _process_size(data):
+def _process_temporal_size(data):
     raise NotImplementedError
 
 
-def _process_not_implemented(data):
+def _process_temporal_not_implemented(data):
     raise NotImplementedError

--- a/mplaltair/_convert.py
+++ b/mplaltair/_convert.py
@@ -65,12 +65,16 @@ def _locate_channel_data(channel, data):
         return channel.value
     elif hasattr(channel, "aggregate") and channel.aggregate is not Undefined:
         return _aggregate_channel()
+    elif hasattr(channel, "timeUnit") and channel.timeUnit is not Undefined:
+        return _handle_timeUnit()
     elif hasattr(channel, "field") and channel.field is not Undefined:
         return data[channel.field].values
     elif hasattr(channel, "shorthand") and channel.shorthand is not Undefined:
         parsed = parse_shorthand(channel.shorthand, data)
         if "aggregate" in parsed:
             return _aggregate_channel()
+        elif "timeUnit" in parsed:
+            return _handle_timeUnit()
         elif "field" in parsed:
             return data[parsed['field']].values
     else:
@@ -78,6 +82,10 @@ def _locate_channel_data(channel, data):
 
 
 def _aggregate_channel():
+    raise NotImplementedError
+
+
+def _handle_timeUnit():
     raise NotImplementedError
 
 

--- a/mplaltair/tests/test_convert.py
+++ b/mplaltair/tests/test_convert.py
@@ -26,9 +26,52 @@ def test_temporal_y(column):
     assert list(mapping['y']) == list(df_temporal[column].values)
 
 
-def test_temporal_scatter():
-    chart = alt.Chart(df_temporal).mark_point().encode(alt.X("years"))
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_color(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Color(column))
     mapping = convert.convert_temporal(chart)
-    mapping["y"] = df_temporal['quantitative'].values
+    assert list(mapping['c']) == list(df_temporal[column].values)
+
+
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_fill(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Fill(column))
+    mapping = convert.convert_temporal(chart)
+    assert list(mapping['c']) == list(df_temporal[column].values)
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_opacity(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Opacity(column))
+    convert.convert_temporal(chart)
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_shape(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Shape(column))
+    convert.convert_temporal(chart)
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_size(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Size(column))
+    mapping = convert.convert_temporal(chart)
+    assert list(mapping['s']) == list(df_temporal[column].values)
+
+
+@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_stroke(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Stroke(column))
+    convert.convert_temporal(chart)
+
+
+@pytest.mark.parametrize("channel", [alt.Color("years"), alt.Fill("years")])
+def test_temporal_scatter(channel):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.X("years"), alt.Y("quantitative"), channel)
+    mapping = convert.convert_temporal(chart)
     plt.scatter(**mapping)
     plt.show()

--- a/mplaltair/tests/test_convert.py
+++ b/mplaltair/tests/test_convert.py
@@ -84,3 +84,9 @@ def test_temporal_scatter(channel):
     mapping['y'] = df_temporal['quantitative'].values
     plt.scatter(**mapping)
     plt.show()
+
+
+@pytest.mark.xfail(raises=NotImplementedError, reason="specifying timeUnit is not supported yet")
+def test_timeUnit():
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.X('date(combination)'))
+    convert.convert_temporal(chart)

--- a/mplaltair/tests/test_convert.py
+++ b/mplaltair/tests/test_convert.py
@@ -26,6 +26,13 @@ def test_temporal_y(column):
     assert list(mapping['y']) == list(df_temporal[column].values)
 
 
+@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_x2_y2(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.X2(column), alt.Y2(column))
+    convert.convert_temporal(chart)
+
+
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_color(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Color(column))
@@ -40,21 +47,21 @@ def test_temporal_fill(column):
     assert list(mapping['c']) == list(df_temporal[column].values)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, reason="The alpha argument in scatter() cannot take arrays")
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_opacity(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Opacity(column))
     convert.convert_temporal(chart)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, reason="The marker argument in scatter() cannot take arrays")
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_shape(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Shape(column))
     convert.convert_temporal(chart)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, reason="Dates would need to be normalized for the size.")
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_size(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Size(column))
@@ -62,7 +69,7 @@ def test_temporal_size(column):
     assert list(mapping['s']) == list(df_temporal[column].values)
 
 
-@pytest.mark.xfail(raises=NotImplementedError)
+@pytest.mark.xfail(raises=NotImplementedError, reason="Stroke is not well defined in Altair")
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_stroke(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Stroke(column))

--- a/mplaltair/tests/test_convert.py
+++ b/mplaltair/tests/test_convert.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
 import altair as alt
 import pandas as pd
 import mplaltair._convert as convert
@@ -16,14 +17,14 @@ df_temporal = pd.DataFrame({
 def test_temporal_x(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.X(column))
     mapping = convert.convert_temporal(chart)
-    assert list(mapping['x']) == list(df_temporal[column].values)
+    assert list(mapping['x']) == list(mdates.date2num(df_temporal[column].values))
 
 
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_y(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Y(column))
     mapping = convert.convert_temporal(chart)
-    assert list(mapping['y']) == list(df_temporal[column].values)
+    assert list(mapping['y']) == list(mdates.date2num(df_temporal[column].values))
 
 
 @pytest.mark.xfail(raises=NotImplementedError)
@@ -37,14 +38,14 @@ def test_temporal_x2_y2(column):
 def test_temporal_color(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Color(column))
     mapping = convert.convert_temporal(chart)
-    assert list(mapping['c']) == list(df_temporal[column].values)
+    assert list(mapping['c']) == list(mdates.date2num(df_temporal[column].values))
 
 
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_fill(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Fill(column))
     mapping = convert.convert_temporal(chart)
-    assert list(mapping['c']) == list(df_temporal[column].values)
+    assert list(mapping['c']) == list(mdates.date2num(df_temporal[column].values))
 
 
 @pytest.mark.xfail(raises=NotImplementedError, reason="The alpha argument in scatter() cannot take arrays")
@@ -58,15 +59,15 @@ def test_temporal_opacity(column):
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_shape(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Shape(column))
-    convert.convert_temporal(chart)
+    mapping = convert.convert_temporal(chart)
+    assert list(mapping['s']) == list(mdates.date2num(df_temporal[column].values))
 
 
 @pytest.mark.xfail(raises=NotImplementedError, reason="Dates would need to be normalized for the size.")
 @pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
 def test_temporal_size(column):
     chart = alt.Chart(df_temporal).mark_point().encode(alt.Size(column))
-    mapping = convert.convert_temporal(chart)
-    assert list(mapping['s']) == list(df_temporal[column].values)
+    convert.convert_temporal(chart)
 
 
 @pytest.mark.xfail(raises=NotImplementedError, reason="Stroke is not well defined in Altair")
@@ -78,7 +79,8 @@ def test_temporal_stroke(column):
 
 @pytest.mark.parametrize("channel", [alt.Color("years"), alt.Fill("years")])
 def test_temporal_scatter(channel):
-    chart = alt.Chart(df_temporal).mark_point().encode(alt.X("years"), alt.Y("quantitative"), channel)
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.X("years"), channel)
     mapping = convert.convert_temporal(chart)
+    mapping['y'] = df_temporal['quantitative'].values
     plt.scatter(**mapping)
     plt.show()

--- a/mplaltair/tests/test_convert.py
+++ b/mplaltair/tests/test_convert.py
@@ -1,0 +1,34 @@
+import matplotlib.pyplot as plt
+import altair as alt
+import pandas as pd
+import mplaltair._convert as convert
+import pytest
+
+df_temporal = pd.DataFrame({
+    "years": pd.date_range('01/01/2015', periods=5, freq='Y'), "months": pd.date_range('1/1/2015', periods=5, freq='M'),
+    "days": pd.date_range('1/1/2015', periods=5, freq='D'), "hrs": pd.date_range('1/1/2015', periods=5, freq='H'),
+    "combination": pd.to_datetime(['1/1/2015', '1/1/2015 10:00:00', '1/2/2015 00:00', '1/4/2016 10:00', '5/1/2016']),
+    "quantitative": [1.1, 2.1, 3.1, 4.1, 5.1]
+})
+
+
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_x(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.X(column))
+    mapping = convert.convert_temporal(chart)
+    assert list(mapping['x']) == list(df_temporal[column].values)
+
+
+@pytest.mark.parametrize("column", ["years", "months", "days", "hrs", "combination"])
+def test_temporal_y(column):
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.Y(column))
+    mapping = convert.convert_temporal(chart)
+    assert list(mapping['y']) == list(df_temporal[column].values)
+
+
+def test_temporal_scatter():
+    chart = alt.Chart(df_temporal).mark_point().encode(alt.X("years"))
+    mapping = convert.convert_temporal(chart)
+    mapping["y"] = df_temporal['quantitative'].values
+    plt.scatter(**mapping)
+    plt.show()


### PR DESCRIPTION
Dates are converted to Matplotlib dates. Conversions involving the timeUnit attribute for encodings are not implemented yet.

Working channel conversions:
x, y, color, fill
Channel conversions not implemented yet:
x2, y2, opacity, shape, size, stroke

I kept the organization of the code consistent with the convert quantitative function, although I'm not happy with this structure.