### PR TITLE
Cleaned up readme (partially closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Matplotlib Backend for Altair Visualization Library
 
 Contributing
 =============
-Want to add features? Docs? Found a bug? Awesome! 
+Want to add docs? Feautures? Found a bug? Awesome! 
  
 Our style guide is [matplotlib](https://matplotlib.org/devel/index.html)'s and we use [pytest](https://docs.pytest.org/en/latest/) for testing. Chat with us on [gitter](https://gitter.im/matplotlib/mpl-altair)
  

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
-Matplotlib Backend for Altair Visualization Library
-==================================================
 [![Join the chat at https://gitter.im/matplotlib/mpl-altair](https://badges.gitter.im/matplotlib/mpl-altair.svg)](https://gitter.im/matplotlib/mpl-altair?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Powered by http://www.numfocus.org](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://www.numfocus.org)
 
-# follow these conventions:
-https://matplotlib.org/devel/index.html
+Matplotlib Backend for Altair Visualization Library
+==================================================
+[Altair](https://altair-viz.github.io/) is a declarative statistical visualization library for Python, based on the [Vega and Vega-Lite](https://vega.github.io/) visualization grammars. This project converts Altair charts to Matplotlib objects that can be modified using the Matplotlib API, rendered as publication-qualuty figures, and integrated with Matplotlib based tools, libraries, and dashboards.
 
-# testing framework:
-[pytest](https://docs.pytest.org/en/latest/)
 
-# dependencies 
-- anything altair or matplotlib depends on
+Contributing
+=============
+Want to add features? Docs? Found a bug? Awesome! 
+ 
+Our style guide is [matplotlib](https://matplotlib.org/devel/index.html)'s and we use [pytest](https://docs.pytest.org/en/latest/) for testing. Chat with us on [gitter](https://gitter.im/matplotlib/mpl-altair)
+ 
+
+Acknowledgments
+================
+Initial work on this project was supported by the [John Hunter Matplotlib Summer Fellowship](https://www.numfocus.org/programs/john-hunter-technology-fellowship).


### PR DESCRIPTION
Since technically this is a public page now, (at https://matplotlib.org/mpl-altair/), trying to make it look slightly less thrown together.