### PR TITLE
[WIP] Reintroduce utils and related functions

### DIFF
--- a/mplaltair/_convert.py
+++ b/mplaltair/_convert.py
@@ -1,6 +1,6 @@
 import matplotlib.dates as mdates
 import numpy as np
-from ._data import _locate_channel_data, _locate_channel_dtype, _convert_to_mpl_date
+from ._data import _locate_channel_data, _locate_channel_dtype, _convert_to_mpl_date, _normalize_data
 
 def _allowed_ranged_marks(enc_channel, mark):
     """TODO: DOCS
@@ -109,6 +109,8 @@ def _convert(chart):
         for later customization.
     """
     mapping = {}
+
+    _normalize_data(chart)
 
     if not chart.to_dict().get('encoding'):
         raise ValueError("Encoding not provided with the chart specification")

--- a/mplaltair/_data.py
+++ b/mplaltair/_data.py
@@ -8,18 +8,17 @@ import pandas as pd
 
 from ._utils import _fetch
 
-def _normalize_data(spec):
+def _normalize_data(chart):
     """Converts the data to a Pandas dataframe
 
     Parameters
     ----------
-    spec : dict
+    chart : altair.Chart
     The vega-lite specification in json format
 
     Returns
     -------
-    dict
-    The vega-lite specification with the data format fixed to a Pandas dataframe
+    None
 
     Raises
     ------
@@ -30,20 +29,19 @@ def _normalize_data(spec):
     Raised when the data specification has an unsupported data source
     """
 
+    spec = chart.to_dict()
+
     if not spec.get('data'):
         raise ValidationError('Please specify a data source.')
     
     if spec['data'].get('url'):
         df = pd.DataFrame(_fetch(spec['data']['url']))
     elif spec['data'].get('values'):
-        df = pd.DataFrame(spec['data']['values'])
+        return
     else:
         raise NotImplementedError('Given data specification is unsupported at the moment.')
 
-    del spec['data']
-    spec['data'] = df
-
-    return spec
+    chart.data = df
 
 def _locate_channel_dtype(chart, channel):
     """Locates dtype used for each channel

--- a/mplaltair/_data.py
+++ b/mplaltair/_data.py
@@ -4,6 +4,47 @@ import matplotlib.cbook as cbook
 from datetime import datetime
 import numpy as np
 
+import pandas as pd
+
+from ._utils import _fetch
+
+def _normalize_data(spec):
+    """Converts the data to a Pandas dataframe
+
+    Parameters
+    ----------
+    spec : dict
+    The vega-lite specification in json format
+
+    Returns
+    -------
+    dict
+    The vega-lite specification with the data format fixed to a Pandas dataframe
+
+    Raises
+    ------
+    ValidationError
+    Raised when the specification does not contain any data attribute
+
+    NotImplementedError
+    Raised when the data specification has an unsupported data source
+    """
+
+    if not spec.get('data'):
+        raise ValidationError('Please specify a data source.')
+    
+    if spec['data'].get('url'):
+        df = pd.DataFrame(_fetch(spec['data']['url']))
+    elif spec['data'].get('values'):
+        df = pd.DataFrame(spec['data']['values'])
+    else:
+        raise NotImplementedError('Given data specification is unsupported at the moment.')
+
+    del spec['data']
+    spec['data'] = df
+
+    return spec
+
 def _locate_channel_dtype(chart, channel):
     """Locates dtype used for each channel
         Parameters

--- a/mplaltair/_data.py
+++ b/mplaltair/_data.py
@@ -31,9 +31,6 @@ def _normalize_data(chart):
 
     spec = chart.to_dict()
 
-    if not spec.get('data'):
-        raise ValidationError('Please specify a data source.')
-    
     if spec['data'].get('url'):
         df = pd.DataFrame(_fetch(spec['data']['url']))
     elif spec['data'].get('values'):

--- a/mplaltair/_utils.py
+++ b/mplaltair/_utils.py
@@ -1,0 +1,42 @@
+from urllib.request import urlopen
+from urllib.error import HTTPError
+
+import pandas as pd
+
+_PD_READERS = {
+    'json': pd.read_json,
+    'csv': pd.read_csv
+}
+
+def _get_format(url):
+    """Gives back the format of the file from url
+
+    WARNING: It might break. Trying to find a better way.
+    """
+    return url.split('.')[-1]
+
+def _fetch(url):
+    """Downloads the file from the given url as a Pandas DataFrame
+
+    Parameters
+    ----------
+    url : string
+    URL of the file to be downloaded
+
+    Returns
+    -------
+    pd.DataFrame
+    Data in the format of a DataFrame
+
+    Raises
+    ------
+    NotImplementedError
+    Raises when an unsupported file format is given as an URL
+    """
+    try:
+        ext = _get_format(url)
+        reader = _PD_READERS[ext]
+        df = reader(urlopen(url).read())
+    except KeyError:
+        raise NotImplementedError('File format not implemented')
+    return df

--- a/mplaltair/tests/test_data.py
+++ b/mplaltair/tests/test_data.py
@@ -18,35 +18,14 @@ df = pd.DataFrame({
 })
 
 def test_data_list():
-    spec = {
-        "data": {
-            "values": [{"a": 1, "b": 2}, {"c": 3, "d": 4}]
-
-        }
-    }
-    assert type(_normalize_data(spec)["data"]) == pd.DataFrame
+    chart = alt.Chart(pd.DataFrame({'a': [1], 'b': [2], 'c': [3]})).mark_point()
+    _normalize_data(chart)
+    assert type(chart.data) == pd.DataFrame
 
 def test_data_url():
-    spec = {
-        "data": {
-            "url": data.cars.url
-        }
-    }
-    assert type(_normalize_data(spec)["data"]) == pd.DataFrame
-
-def test_data_no_pass():
-    spec = {}
-    with pytest.raises(ValidationError):
-        _normalize_data(spec)
-
-def test_data_invalid():
-    spec = {
-        "data": {
-            "source": "path"
-        }
-    }
-    with pytest.raises(NotImplementedError):
-        _normalize_data(spec)
+    chart = alt.Chart(data.cars.url).mark_point()
+    _normalize_data(chart)
+    assert type(chart.data) == pd.DataFrame
 
 # _locate_channel_data() tests
 

--- a/mplaltair/tests/test_data.py
+++ b/mplaltair/tests/test_data.py
@@ -3,6 +3,10 @@ import pandas as pd
 import matplotlib.dates as mdates
 import mplaltair._data as _data
 import pytest
+from vega_datasets import data
+
+from mplaltair._data import _normalize_data
+from mplaltair._exceptions import ValidationError
 
 df = pd.DataFrame({
     "a": [1, 2, 3, 4, 5], "b": [1.1, 2.2, 3.3, 4.4, 5.5], "c": [1, 2.2, 3, 4.4, 5],
@@ -13,6 +17,36 @@ df = pd.DataFrame({
     "quantitative": [1.1, 2.1, 3.1, 4.1, 5.1]
 })
 
+def test_data_list():
+    spec = {
+        "data": {
+            "values": [{"a": 1, "b": 2}, {"c": 3, "d": 4}]
+
+        }
+    }
+    assert type(_normalize_data(spec)["data"]) == pd.DataFrame
+
+def test_data_url():
+    spec = {
+        "data": {
+            "url": data.cars.url
+        }
+    }
+    assert type(_normalize_data(spec)["data"]) == pd.DataFrame
+
+def test_data_no_pass():
+    spec = {}
+    with pytest.raises(ValidationError):
+        _normalize_data(spec)
+
+def test_data_invalid():
+    spec = {
+        "data": {
+            "source": "path"
+        }
+    }
+    with pytest.raises(NotImplementedError):
+        _normalize_data(spec)
 
 # _locate_channel_data() tests
 

--- a/mplaltair/tests/test_utils.py
+++ b/mplaltair/tests/test_utils.py
@@ -1,0 +1,15 @@
+import pytest
+import pandas as pd
+from vega_datasets import data
+
+from mplaltair import _utils
+
+def test_get_format():
+    assert _utils._get_format(data.cars.url) == 'json'
+
+def test_fetch_success():
+    assert type(_utils._fetch(data.cars.url)) == pd.DataFrame
+
+def test_fetch_error():
+    with pytest.raises(NotImplementedError):
+        _utils._fetch('https://test.tld/dataset.tsv')


### PR DESCRIPTION
This had the functionality to normalize the chart specification by downloading the data if specified as an URL.

It has some caveats as of now, as I was operating on the schema as a dictionary, while the current implementation on the master operates on the schema assuming it to be a `altair.Chart` object. I tried to use the Altair top-level function `altair.BaseSchema.from_dict` to convert the output of the `mplaltair._data._normalize_data` function to an `altair.Chart` object but that is not working for some reason.

We will be discussing this after the scheduled call as @kdorr  has some inputs.