### PR TITLE
Use older dependencies and make tests pass

### DIFF
--- a/mplaltair/_data.py
+++ b/mplaltair/_data.py
@@ -34,6 +34,12 @@ def _normalize_data(chart):
         df = pd.DataFrame(_fetch(spec['data']['url']))
     elif spec['data'].get('values'):
         return
+    elif spec['data'].get('name'):
+        datasets = spec.get('datasets', {})
+        if spec['data'].get('name') in datasets.keys():
+            return
+        else:
+            raise ValidationError('Named Data is provided but no corresponding dataset is found')
     else:
         raise NotImplementedError('Given data specification is unsupported at the moment.')
 

--- a/mplaltair/tests/test_data.py
+++ b/mplaltair/tests/test_data.py
@@ -2,6 +2,7 @@ import altair as alt
 import pandas as pd
 import matplotlib.dates as mdates
 import mplaltair._data as _data
+from mplaltair._exceptions import ValidationError
 import pytest
 from vega_datasets import data
 
@@ -25,6 +26,12 @@ def test_data_url():
     chart = alt.Chart(data.cars.url).mark_point()
     _data._normalize_data(chart)
     assert type(chart.data) == pd.DataFrame
+
+
+def test_named_data():
+    chart = alt.Chart(alt.NamedData('test-dataset')).mark_point()
+    with pytest.raises(ValidationError):
+        _data._normalize_data(chart)
 
 # test date conversion:
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup_parameters = dict(
     version='0.0.0',
     description="Convert altair objects to Matplotlib Figures",
     author="Matplotlib Development Team",
-    install_requires=['matplotlib>=2.2.0', 'altair>=2'],
+    install_requires=['matplotlib<3.0', 'altair<3.0','pandas<0.25'],
     author_email="matplotlib-users@python.org",
     url="https://github.com/matplotlib/mpl-altair",
     packages=['mplaltair'],


### PR DESCRIPTION
Quick update to fix the build. 

Using older dependencies for now, next step will be to update altair, matplotlib and pandas.